### PR TITLE
ログイン済ユーザーのみ利用できる仕様の撤廃

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import 'font-awesome';
 @import 'mixin/responsive';
 @import 'mixin/user_image';
+@import 'mixin/header_item';
 @import 'base/base';
 @import 'module/header';
 @import 'module/devise';

--- a/app/assets/stylesheets/mixin/_header_item.scss
+++ b/app/assets/stylesheets/mixin/_header_item.scss
@@ -1,0 +1,5 @@
+@mixin header-item() {
+  color: pink;
+  font-size: small;
+  margin-right: 20px;
+}

--- a/app/assets/stylesheets/module/_header.scss
+++ b/app/assets/stylesheets/module/_header.scss
@@ -68,5 +68,11 @@
         }
       }
     }
+    .login {
+      @include header-item();
+    }
+    .new-registration {
+      @include header-item();
+    }
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   require 'rspotify'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!, only: [:create, :edit, :update, :destroy]
   before_action :set_post, only: [:edit, :update, :destroy]
   before_action :move_to_index, only: [:edit, :update, :destroy]
 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -5,7 +5,7 @@
     %span
       = link_to "https://www.spotify.com" do
         supprted by Spotify
-  -if user_signed_in?
+  - if user_signed_in?
     .header__info
       = link_to musics_path do
         %i.fas.fa-pencil-alt.new-post

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -23,3 +23,9 @@
         %li.header__info__list__sign-out
           = link_to destroy_user_session_path, method: "delete" do
             %i.fas.fa-sign-out-alt
+  - else
+    .header__info
+      = link_to musics_path do
+        %i.fas.fa-pencil-alt.new-post
+      = link_to "ログイン", new_user_session_path, class: "login"
+      = link_to "新規登録", new_user_registration_path, class: "new-registration"

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -12,7 +12,7 @@
       %li.daytime
         = post.created_at
       %li.edit
-        - if post.user.id == current_user.id
+        - if post.user.id == current_user&.id
           = link_to edit_post_path(post) do
             %i.fas.fa-angle-double-down
   .post__contents

--- a/app/views/posts/_posts_new.html.haml
+++ b/app/views/posts/_posts_new.html.haml
@@ -10,7 +10,7 @@
       %li.daytime
         = post.created_at
       %li.edit
-        - if post.user.id == current_user.id
+        - if post.user.id == current_user&.id
           = link_to edit_post_path(post) do
             %i.fas.fa-angle-double-down
   .post__content


### PR DESCRIPTION
# What
ログインしているユーザーのみがこのアプリケーションを利用できる仕様でしたが、コメントの投稿・編集・削除以外はアカウントなしでも行えるよう使用を変更します。
# Why
より利用者の方が気軽に機能を使用できるようにするため。
また、初めにログイン・新規登録を強要されることに窮屈さを感じたため。